### PR TITLE
Describe both load orders when the original card is also installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,15 @@ and `custom:decluttering-template-plus` types, this card also registers the orig
 not installed. The `decluttering_templates` key is unchanged. So you can install this, remove
 the old card, and change nothing else.
 
-If you install both cards at once, whichever loads first claims the shared types and this one
-logs a warning for the ones it skipped. That works, but there is no reason to run both — pick one.
+If you install both cards at once, whichever loads first claims `decluttering-card` and
+`decluttering-template`. Home Assistant loads resources in the order they were added, so the
+original card usually wins and carries on serving your existing `custom:decluttering-card`
+cards — they keep working, but they get none of the fixes here until you remove the original
+card. In the other order this card serves them instead, and the original's bundle logs a
+`define` error to the console when it finds the name already taken; nothing breaks, because
+the type is already being served.
+
+Either way, there is no reason to run both. Remove the original card.
 
 New configuration should use `custom:decluttering-card-plus` and
 `custom:decluttering-template-plus`, which are always available.


### PR DESCRIPTION
The compatibility behaviour was tested against the real `custom-cards/decluttering-card` v1.0.0 release asset, not a stub, in both load orders:

| Load order | `decluttering-card` served by | Result |
| --- | --- | --- |
| Original first, then this card | the original | Existing cards work unchanged. This card skips the tag with a warning and keeps its own types. |
| This card first, then original | this card's alias | Existing cards work with the fixes. The original's bundle throws on its own `define` and stops evaluating — harmless, as v1.0.0 registers nothing else. |

`document.createElement('decluttering-card')` produced a working element with a `setConfig` in both orders, and there were no uncaught page errors.

The README only described the first order. It now says which one users actually land in — HA loads resources in the order they were added, so the original usually wins and existing cards keep running the old implementation until it is removed.