### PR TITLE
Give the release job write permission, and validate against HACS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: npm
@@ -33,9 +33,9 @@ jobs:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,22 @@
+name: HACS
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 4 * * 1'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: plugin

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -15,7 +15,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: HACS validation
         uses: hacs/action@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,13 @@ name: Release
 
 on: workflow_dispatch
 
+# semantic-release tags the commit, pushes the changelog and version bump back, and
+# creates the GitHub release. The default token is read-only, so all three would fail.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two things found while checking release readiness.

**The release workflow would have failed on its first run.** semantic-release tags the commit, pushes the changelog and version bump back via `@semantic-release/git`, and creates the GitHub release. All three need `contents: write`, and this repo's default `GITHUB_TOKEN` is `Contents: read` — visible in the CI logs of every run so far. Adds the `permissions` block.

**Adds `hacs/action` plugin validation.** The `hacs/default` submission requires that check to pass, so running it now tells us what is still missing instead of finding out inside the store PR.