### PR TITLE
Accept main as well as master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
+    branches: [master, main]
   push:
-    branches: [master]
+    branches: [master, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -10,7 +10,7 @@ name: HACS
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [master, main]
   schedule:
     - cron: '0 4 * * 1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release-bundle:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
 
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}

--- a/release.config.js
+++ b/release.config.js
@@ -45,5 +45,5 @@ module.exports = {
     ],
   ],
   preset: 'conventionalcommits',
-  branches: [{ name: 'master' }, { name: 'dev', channel: 'beta', prerelease: true }],
+  branches: [{ name: 'master' }, { name: 'main' }, { name: 'dev', channel: 'beta', prerelease: true }],
 };


### PR DESCRIPTION
First half of renaming the default branch to `main`. Accepting both names means the rename itself cannot leave a window where pushes and pull requests match no trigger, or where semantic-release refuses to release from the branch it is on.

A follow-up drops `master` once the rename is done.