### PR TITLE
Finish the move to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master, main]
+    branches: [main]
   push:
-    branches: [master, main]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -2,15 +2,15 @@ name: HACS
 
 # Deliberately not run on pull_request. HACS resolves the repository through GitHub's API
 # and reads its metadata - description, topics, licence - from the DEFAULT branch, so a
-# pull request is graded against master rather than against itself. That makes the result
+# pull request is graded against main rather than against itself. That makes the result
 # say nothing true about the change, and each failure emails the repository owner while
-# the meaningful checks are still running. master is what actually determines HACS
+# the meaningful checks are still running. main is what actually determines HACS
 # publishability, so push, nightly and on demand gives full coverage without the noise.
 
 on:
   workflow_dispatch:
   push:
-    branches: [master, main]
+    branches: [main]
   schedule:
     - cron: '0 4 * * 1'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release-bundle:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
 
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Save [decluttering-card-plus.js][latest-release] to `<config directory>/www/decl
 **Example:**
 
 ```bash
-wget https://raw.githubusercontent.com/tempus2016/decluttering-card-plus/master/dist/decluttering-card-plus.js
+wget https://raw.githubusercontent.com/tempus2016/decluttering-card-plus/main/dist/decluttering-card-plus.js
 mv decluttering-card-plus.js /config/www/
 ```
 
@@ -577,7 +577,7 @@ npm start       # rebuild on change, served on :5000 for the dev container
 ```
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/tempus2016/decluttering-card-plus.svg?style=for-the-badge
-[commits]: https://github.com/tempus2016/decluttering-card-plus/commits/master
+[commits]: https://github.com/tempus2016/decluttering-card-plus/commits/main
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/t/lovelace-decluttering-card/118625
 [j9brown]: https://github.com/j9brown/decluttering-card

--- a/release.config.js
+++ b/release.config.js
@@ -45,5 +45,5 @@ module.exports = {
     ],
   ],
   preset: 'conventionalcommits',
-  branches: [{ name: 'master' }, { name: 'main' }, { name: 'dev', channel: 'beta', prerelease: true }],
+  branches: [{ name: 'main' }, { name: 'dev', channel: 'beta', prerelease: true }],
 };


### PR DESCRIPTION
Drops `master` now that the default branch is renamed: workflow triggers, the release job's branch guard, semantic-release's branch list, and the two README links.

`raw.githubusercontent.com` does not follow GitHub's rename redirect, so the manual install `wget` would have 404'd.