### PR TITLE
Set the Home Assistant floor to 2024.7.0, matching TaskMate

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,9 @@ and does not reach the card.
 
 ## Installation
 
+Requires Home Assistant 2024.7 or newer. Badge templates need 2024.8, since that is when
+Home Assistant made badges configurable.
+
 ### Using HACS
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=tempus2016&repository=decluttering-card-plus&category=lovelace)

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Decluttering Card Plus",
-  "homeassistant": "2024.8.0",
+  "homeassistant": "2024.7.0",
   "render_readme": true,
   "filename": "decluttering-card-plus.js"
 }


### PR DESCRIPTION
Matches TaskMate's `hacs.json`, keeping the minimum consistent across projects.

One consequence worth noting: 2024.7 is one release below the 2024.8 that made badges configurable, so a user on 2024.7 can install this and find badge templates do nothing. The README now says so; everything else works from 2024.7.