### PR TITLE
Restore dependency review now the dependency graph is enabled

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+name: Dependency review
+
+# Fails a pull request that introduces a dependency with a known vulnerability, or one
+# under a licence this project will not ship. Only build tooling and lit are in scope
+# today, and this is the gate that keeps it that way. Needs the repository's dependency
+# graph enabled, or the action refuses to run at all.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
Held back in #19 because the action cannot run without the dependency graph, which has no REST enable endpoint. The graph is on now — the SBOM endpoint answers 200 — so the check goes back in.

This PR is also its own proof: the check has to pass here.