### PR TITLE
Write the 1.0.0 release notes, and take copyright of the fork

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
-
 The MIT License (MIT)
-Copyright (c) 2018, Alexandre Garcia
+
+Copyright (c) 2026 John MacKinnon
+Copyright (c) 2018 Alexandre Garcia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ It is now maintained here as its own project, with badge templates, templates sh
 dashboards, `visibility` support inside templates, and a series of variable-substitution and
 layout fixes on top of that work.
 
-Everything here is MIT licensed, as was all of the work it builds on.
+This project is maintained by [tempus2016](https://github.com/tempus2016) and is copyright
+2026 John MacKinnon. It began as a fork of RomRider's `decluttering-card`, which is copyright
+2018 Alexandre Garcia, and parts of that original card remain in it — so both notices are
+carried in [LICENSE](LICENSE). Everything here is MIT licensed, as was all of the work it
+builds on.
 
 ## Migrating from `decluttering-card`
 

--- a/docs/release-notes/1.0.0.md
+++ b/docs/release-notes/1.0.0.md
@@ -1,0 +1,71 @@
+The first release of **Decluttering Card Plus**, a maintained continuation of
+[custom-cards/decluttering-card](https://github.com/custom-cards/decluttering-card), which has
+not had a release since April 2023.
+
+It combines three generations of work — RomRider's original card, [j9brown's visual
+editors](https://github.com/custom-cards/decluttering-card/pull/78), and simbaja's
+modernisation — and adds to them.
+
+### Installing it over the original card
+
+Your existing configuration keeps working. As well as its own `custom:decluttering-card-plus`
+and `custom:decluttering-template-plus` types, this card registers the original
+`custom:decluttering-card` and `custom:decluttering-template` types when the original is not
+installed, and the `decluttering_templates` key is unchanged. Install this, remove the old
+card, change nothing else.
+
+Home Assistant loads resources in the order they were added, so if you keep both installed the
+original usually wins and your existing cards go on using it. Remove it to get the fixes below.
+
+### New
+
+- **Badges.** A template can hold a `badge:`, used from a view's `badges:` list.
+- **Templates shared between dashboards.** `decluttering_templates_from:` lets one dashboard
+  borrow another's templates, so a template library can live in one place.
+- **Sharing a template with other people.** The template editor has a **Share** tab that
+  exports a template as YAML — naming the custom cards and other templates it depends on — and
+  imports one somebody sent you.
+- **`visibility` conditions inside templates**, including variables inside the conditions
+  themselves. A hidden card collapses instead of leaving a gap.
+- **Nested variables.** A variable's value can contain other variables, resolved in any order.
+
+### Fixed
+
+Long-standing issues from the original tracker, all verified against a real dashboard:
+
+- Values containing a newline, a double quote, a backslash or a tab no longer break the card
+  with `JSON.parse` errors — that is every multi-line value and every Jinja template written as
+  a YAML block scalar ([#47](https://github.com/custom-cards/decluttering-card/issues/47),
+  [#60](https://github.com/custom-cards/decluttering-card/issues/60)).
+- An object used inside a longer string is substituted as JSON instead of being left as
+  `[[name]]` ([#83](https://github.com/custom-cards/decluttering-card/issues/83)).
+- Templated cards are sized correctly in the sections layout instead of always taking the
+  default size ([#59](https://github.com/custom-cards/decluttering-card/issues/59),
+  [#80](https://github.com/custom-cards/decluttering-card/issues/80),
+  [#87](https://github.com/custom-cards/decluttering-card/issues/87)).
+- `fill_container` fills the container ([#72](https://github.com/custom-cards/decluttering-card/issues/72)),
+  and an iframe in a panel view fills the panel
+  ([#24](https://github.com/custom-cards/decluttering-card/issues/24)).
+- A card that hides itself no longer leaves an empty space behind it
+  ([#58](https://github.com/custom-cards/decluttering-card/issues/58)).
+- Generated cards no longer share a duplicate `declutter-child` id
+  ([#55](https://github.com/custom-cards/decluttering-card/issues/55)).
+- Defaults can reference other variables
+  ([#62](https://github.com/custom-cards/decluttering-card/issues/62),
+  [#84](https://github.com/custom-cards/decluttering-card/issues/84)).
+
+### Requirements
+
+Home Assistant 2024.7 or newer. Badge templates need 2024.8, which is when badges became
+configurable.
+
+### Documentation
+
+The [wiki](https://github.com/tempus2016/decluttering-card-plus/wiki) has a page per feature,
+a [quick start](https://github.com/tempus2016/decluttering-card-plus/wiki/Quick-Start), and a
+[migration guide](https://github.com/tempus2016/decluttering-card-plus/wiki/Migrating-from-decluttering-card).
+
+With thanks to [RomRider](https://github.com/RomRider),
+[j9brown](https://github.com/j9brown/decluttering-card) and
+[simbaja](https://github.com/simbaja/ha-decluttering-card), whose work this is built on. All
+MIT licensed.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,8 +8,9 @@ export default [
   ...tseslint.configs.recommended,
   prettierRecommended,
   {
-    // The test runner is a plain CommonJS Node script, not part of the bundle.
-    files: ['test/**/*.js'],
+    // The test runner and the release scripts are plain CommonJS Node scripts, not
+    // part of the bundle.
+    files: ['test/**/*.js', 'scripts/**/*.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
     },

--- a/release.config.js
+++ b/release.config.js
@@ -28,6 +28,9 @@ module.exports = {
       // and attached to the release carries it too.
       '@semantic-release/exec',
       {
+        // Appended to the generated notes. See scripts/release-notes.js.
+        generateNotesCmd: 'node scripts/release-notes.js ${nextRelease.version}',
+        // Rebuild once the new version is in package.json.
         prepareCmd: 'npm run build',
       },
     ],

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/*
+ * Prints the hand-written notes for a release, if there are any.
+ *
+ * semantic-release concatenates the output of every generateNotes plugin, so whatever this
+ * prints is appended to the list the commit analyser produces. That list is only as good as
+ * the commit subjects behind it — squash merges with prose titles produce almost nothing —
+ * so this is where a release gets an actual description.
+ *
+ * Silent when docs/release-notes/<version>.md does not exist, which leaves the generated
+ * notes standing on their own.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const version = process.argv[2];
+if (!version) process.exit(0);
+
+const file = path.join(__dirname, '..', 'docs', 'release-notes', `${version}.md`);
+if (!fs.existsSync(file)) process.exit(0);
+
+process.stdout.write(`${fs.readFileSync(file, 'utf8').trim()}\n`);


### PR DESCRIPTION
Two things before the release can go out.

### The 1.0.0 notes would have been empty

The generated notes came out as a bare `## 1.0.0 (2026-08-18)` and nothing else. The squash-merge subjects on `main` are prose rather than conventional commits, so the commit analyser has almost nothing to list, and `chore` is hidden.

semantic-release concatenates the output of **every** generateNotes plugin, so `scripts/release-notes.js` prints `docs/release-notes/<version>.md` when one exists and the exec plugin appends it to whatever was generated. Silent when there is no file, so later releases can rely on generated notes alone.

1.0.0's notes are written: what it is, how it sits alongside the original card, what is new, the upstream issues it fixes with links, requirements, and credits. Verified end to end with `semantic-release --dry-run --branches release-prep` — the notes appear under the version heading.

### Copyright

`LICENSE` now carries **John MacKinnon's copyright first**, and the README says plainly who maintains this project and where it came from.

Alexandre Garcia's line stays beneath it. Parts of the original card are still in this code, and MIT requires the notice to travel with them — dropping it would put every installation of this card in breach, not just this repository. Listing the current maintainer first is the normal way a fork shows ownership, and it does not cost anything.