### PR TITLE
fix: generate real release notes, and stop the release run failing after publishing

### DIFF
--- a/docs/release-notes/1.0.0.md
+++ b/docs/release-notes/1.0.0.md
@@ -1,5 +1,3 @@
-## 1.0.0 (2026-08-18)
-
 The first release of **Decluttering Card Plus**, a maintained continuation of
 [custom-cards/decluttering-card](https://github.com/custom-cards/decluttering-card), which has
 not had a release since April 2023.
@@ -88,22 +86,3 @@ With thanks to [RomRider](https://github.com/RomRider),
 [j9brown](https://github.com/j9brown/decluttering-card) and
 [simbaja](https://github.com/simbaja/ha-decluttering-card), whose work this is built on. All
 MIT licensed.
-
-# Changelog
-
-Releases of this fork are listed here as they are made. The entries below the first
-release are the history inherited from the projects this one builds on, kept for
-provenance and labelled with where they came from.
-
-## simbaja/ha-decluttering-card 2026.2.0 (2026-02-21)
-
-### Features
-
-- **Styling:** Added support for injecting custom CSS styles into cards and templates via the `style` property.
-- **Container:** Added `decluttering-container` class to the host element for easier CSS targeting.
-
-## custom-cards/decluttering-card 1.0.0 (2023-04-02)
-
-### Bug Fixes
-
-- card broken with HA 2023.4 beta and up ([0ccd5b0](https://github.com/custom-cards/decluttering-card/commit/0ccd5b05a99202c80de21606df1b8e94ea9ee668)), closes [#63](https://github.com/custom-cards/decluttering-card/issues/63)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@semantic-release/git": "^11.0.1",
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.1",
-        "conventional-changelog-conventionalcommits": "^10.3.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
@@ -121,16 +121,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
-      "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2246,16 +2236,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
-      "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.3.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@semantic-release/git": "^11.0.1",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.1",
-    "conventional-changelog-conventionalcommits": "^10.3.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",

--- a/release.config.js
+++ b/release.config.js
@@ -44,6 +44,10 @@ module.exports = {
       '@semantic-release/github',
       {
         assets: 'dist/*.js',
+        // Commit messages cite issue numbers from the upstream repository, which do not
+        // exist here; the comment step fails the whole run trying to resolve them.
+        successComment: false,
+        failComment: false,
       },
     ],
   ],


### PR DESCRIPTION
The v1.0.0 release published correctly (tag, asset, version bump) but with a bare heading for notes, and the workflow run then failed in the post-publish step. Three causes:

- `conventional-changelog-conventionalcommits@10` is incompatible with `release-notes-generator@14` — with the preset configured the writer emits the heading and nothing else (verified by driving the generator directly; the same config over v8 produces proper Features/Bug Fixes sections). Pinned to `^8`.
- The GitHub plugin's success step failed the run trying to comment on issue "#63", an upstream issue number cited in an inherited commit message. `successComment`/`failComment` disabled.
- The hand-written 1.0.0 notes were kept off main by design but never added back when the release was cut. Restored to `docs/release-notes/1.0.0.md`, extended to cover the typed-variables/for_each/transforms/where-used work, and folded into the bare CHANGELOG entry.

The v1.0.0 release body on GitHub will be updated to match once this merges.