### PR TITLE
chore: drop the inert ip-address override and hold TypeScript at 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,10 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # typescript-eslint's peer range is >=4.8.4 <6.1.0, so TypeScript 7 breaks
+      # `npm run lint` — and lint is the first half of `npm run build`. Revisit
+      # once typescript-eslint declares TS 7 support.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "overrides": {
     "braces": "^3.0.3",
     "brace-expansion": "^5.0.9",
-    "ip-address": "^10.5.0",
     "lodash-es": "^4.18.1",
     "micromatch": "^4.0.8"
   },


### PR DESCRIPTION
Two small pieces of dependency hygiene, prompted by the six open Dependabot alerts.

### The `ip-address` override never did anything

`package.json` carried `"ip-address": "^10.5.0"` in `overrides`. The only `ip-address` anywhere in the tree is:

```
node_modules/npm/node_modules/ip-address  10.2.0  inBundle: true
```

npm ships its own dependencies pre-bundled, and overrides cannot rewrite bundled packages — so that line has been inert since the day it was added, while looking like the alerts were dealt with.

Verified before removing: regenerating `package-lock.json` with the line gone produces **0 version changes, 0 packages added, 0 removed**. The lockfile in this PR is byte-identical to the one on `main`. The other four overrides resolve to real non-bundled copies and are untouched.

### The alerts have no fix

All six (3x `ip-address`, 3x `undici`) sit inside npm's bundled payload, pulled in by `@semantic-release/npm` -> `npm@^11.6.2`. There is nothing to upgrade to:

```
npm 11.19.0 -> ip-address 10.2.0 | undici 6.27.0
npm 12.0.2  -> ip-address 10.2.0 | undici 6.27.0   (current latest)
```

Every one is development-scoped and transitive; `grep` over `dist/decluttering-card-plus.js` finds no trace of either package. They will be dismissed as "vulnerable code is not actually used" rather than patched.

### Holding TypeScript at 5.x

`typescript@7.0.2` is out, but `typescript-eslint@8.67.0` declares `peerDependencies.typescript: >=4.8.4 <6.1.0`. Since `build` is `npm run lint && npm run rollup`, a major bump takes down the whole build, not just linting. Added an `ignore` entry so Dependabot stops offering it; the comment records when to revisit.

### Checks

`npm ci` clean, `eslint .` clean, 11/11 tests passing locally.