### PR TITLE
chore: stop Dependabot proposing conventional-changelog-conventionalcommits 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,14 @@ updates:
       - dependency-name: 'typescript'
         update-types:
           - 'version-update:semver-major'
+      # conventional-changelog-conventionalcommits 10 swapped its template
+      # engine for @conventional-changelog/template, but semantic-release 25
+      # resolves conventional-changelog-writer 8, which expects the old shape.
+      # The preset loads without error and renders an empty changelog -- the
+      # release notes drop to just the version heading. It also raises
+      # engines.node to >=22, which the 20.x leg of the build matrix violates.
+      # Revisit when semantic-release moves to the v9+ conventional-changelog
+      # family. Evidence: PR #42.
+      - dependency-name: 'conventional-changelog-conventionalcommits'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
Follow-up to #42, which is closed with the evidence in a comment there.

`conventional-changelog-conventionalcommits@10` renders an empty changelog under `semantic-release@25`. Confirmed with `semantic-release --dry-run` from a clean clone, on a branch named `main` so `generateNotes` actually runs:

| | notes produced |
|---|---|
| `8.0.0` (current) | 10 lines — heading + Bug Fixes + Documentation, each commit listed |
| `10.3.0` | 2 lines — the version heading, nothing else |

Exit code 0 either way. No error, no warning.

**Cause:** v10 dropped `compare-func` for `@conventional-changelog/template`. `semantic-release@25` resolves `conventional-changelog-writer@8.4.0`, which expects the previous template shape — it loads the preset happily and renders nothing. v10 also raises `engines.node` to `>=22`, which the `20.x` leg of the build matrix violates (`EBADENGINE`, non-fatal without `engine-strict`).

**Why CI could not catch it:** the workflows run `eslint`, `rollup` and the unit tests. None touch the release pipeline. #42 was five-for-five green and would still have shipped a release with a blank changelog.

Adds a second `ignore` entry beside the `typescript` one, with the reasoning and the revisit condition in a comment. Config-only change — no dependency or lockfile movement.