### PR TITLE
ci: fail the build when a release would ship an empty changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # On a pull request the checkout is a detached merge commit, and semantic-release
-      # only generates notes on a branch its config names — so the run is pointed at a
-      # local branch called main, which also means the notes describe the merge result
-      # rather than the branch tip. --no-ci is required regardless: in CI on a pull
-      # request semantic-release otherwise stops before generateNotes.
+      # semantic-release only generates notes on a branch its config names, and it takes
+      # that name from env-ci rather than from git: on a pull_request event env-ci reports
+      # prBranch, which is the merge ref (44/merge), and checking out a local main changes
+      # nothing. Presenting the run as a push to main is what gets past that. The checkout
+      # is still pointed at main so git agrees, and because a pull request checkout is the
+      # merge commit, the notes describe the merge result rather than the branch tip.
+      # --no-ci is needed as well: on a pull request semantic-release otherwise stops
+      # before generateNotes (semantic-release/index.js:59).
       - name: Generate the notes a release would produce
         shell: bash
         run: |
@@ -106,6 +109,8 @@ jobs:
           npx semantic-release --dry-run --no-ci --branches main 2>&1 | tee /tmp/dry-run.log
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_NAME: push
+          GITHUB_REF: refs/heads/main
 
       # An empty changelog is the failure to catch, and it exits 0, so the notes have to
       # be inspected rather than the status code. Every generated entry links to its

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,8 @@ jobs:
           git --git-dir=/tmp/release-remote.git update-ref refs/heads/main "$(git rev-parse 'HEAD^1')"
           git config url."file:///tmp/release-remote.git".insteadOf "$origin_url"
 
-          env -u GITHUB_TOKEN -u GH_TOKEN RELEASE_NOTES_CHECK=1 \
+          env -u GITHUB_TOKEN -u GH_TOKEN \
+            GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main RELEASE_NOTES_CHECK=1 \
             npx semantic-release --dry-run --no-ci --branches main \
               --repository-url "$origin_url" 2>&1 | tee /tmp/dry-run.log
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,24 +94,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # semantic-release only generates notes on a branch its config names, and it takes
-      # that name from env-ci rather than from git: on a pull_request event env-ci returns
-      # the merge ref, so checking out a local main changes nothing on its own. Presenting
-      # the run as a push to main is what gets past that, and it has to be done with env(1)
-      # rather than a step-level env: block — the runner re-injects its own GITHUB_* values
-      # over anything declared there, which is why the previous attempt still saw
-      # refs/pull/<n>/merge. The checkout is pointed at main as well so git agrees, and
-      # because a pull request checkout is the merge commit, the notes describe the merge
-      # result rather than the branch tip. --no-ci is needed too: on a pull request
-      # semantic-release otherwise stops before generateNotes (semantic-release/index.js:59).
+      # Three things stand between a pull request and generated notes. semantic-release
+      # takes the branch name from env-ci, not from git, and on a pull_request event that
+      # is the merge ref — and a step-level env: block cannot correct it, because the
+      # runner re-injects its own GITHUB_* values over anything declared there, so the
+      # override goes through env(1). --no-ci is needed too, or it stops before
+      # generateNotes (semantic-release/index.js:59). Last, it insists on being able to
+      # push, and verifyAuth failing is fatal either way — an up-to-date branch rethrows
+      # as EGITNOPERMISSION (index.js:97).
+      #
+      # Rather than hand a write-scoped token to a job that checks out pull request code,
+      # git is pointed at a throwaway bare clone whose main is the base commit, which it
+      # is trivially allowed to push to. semantic-release still gets the real GitHub URL,
+      # because the notes embed it in every commit link and a file:// URL would leave the
+      # entries unlinked; insteadOf redirects git underneath it. Which commits the notes
+      # cover is decided by the release tags, so the stand-in remote costs no fidelity.
       - name: Generate the notes a release would produce
         shell: bash
         run: |
+          origin_url=$(git remote get-url origin)
+
           git checkout -B main
-          env GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
-            npx semantic-release --dry-run --no-ci --branches main 2>&1 | tee /tmp/dry-run.log
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git clone --bare --quiet . /tmp/release-remote.git
+          git --git-dir=/tmp/release-remote.git update-ref refs/heads/main "$(git rev-parse 'HEAD^1')"
+          git config url."file:///tmp/release-remote.git".insteadOf "$origin_url"
+
+          env -u GITHUB_TOKEN -u GH_TOKEN RELEASE_NOTES_CHECK=1 \
+            npx semantic-release --dry-run --no-ci --branches main \
+              --repository-url "$origin_url" 2>&1 | tee /tmp/dry-run.log
 
       # An empty changelog is the failure to catch, and it exits 0, so the notes have to
       # be inspected rather than the status code. Every generated entry links to its

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,3 +71,67 @@ jobs:
             git status --porcelain --ignored=matching -- dist/
             exit 1
           fi
+
+  # Nothing else here runs semantic-release, so a dependency that quietly breaks note
+  # generation ships a release with an empty changelog while every check stays green.
+  # That is not hypothetical: conventional-changelog-conventionalcommits 10 rendered
+  # notes down to the bare version heading, exit code 0, and PR #42 was five-for-five.
+  release-notes:
+    name: Release notes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # semantic-release finds the last release from the tags and walks every commit
+          # since it. A shallow clone has neither, so it invents a first release instead.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+
+      # On a pull request the checkout is a detached merge commit, and semantic-release
+      # only generates notes on a branch its config names — so the run is pointed at a
+      # local branch called main, which also means the notes describe the merge result
+      # rather than the branch tip. --no-ci is required regardless: in CI on a pull
+      # request semantic-release otherwise stops before generateNotes.
+      - name: Generate the notes a release would produce
+        shell: bash
+        run: |
+          git checkout -B main
+          npx semantic-release --dry-run --no-ci --branches main 2>&1 | tee /tmp/dry-run.log
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # An empty changelog is the failure to catch, and it exits 0, so the notes have to
+      # be inspected rather than the status code. Every generated entry links to its
+      # commit, which makes those links the thing to count.
+      - name: Fail if the notes came back empty
+        shell: bash
+        run: |
+          log=/tmp/dry-run.log
+
+          if grep -q "no new version is released" "$log"; then
+            echo "No release would be cut from these commits, so there are no notes to check."
+            exit 0
+          fi
+
+          if ! grep -q "Release note for version" "$log"; then
+            echo "::error::semantic-release reported a release but printed no notes."
+            exit 1
+          fi
+
+          notes=$(sed -n '/Release note for version/,$p' "$log")
+          entries=$(printf '%s\n' "$notes" | grep -cE '/commit/[0-9a-f]{7,}' || true)
+
+          if [ "$entries" -eq 0 ]; then
+            echo "::error::The release notes contain no commit entries. The changelog would ship empty — check whether a conventional-changelog dependency moved."
+            printf '%s\n' "$notes"
+            exit 1
+          fi
+
+          echo "Release notes carry $entries commit entries."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,22 +95,23 @@ jobs:
         run: npm ci
 
       # semantic-release only generates notes on a branch its config names, and it takes
-      # that name from env-ci rather than from git: on a pull_request event env-ci reports
-      # prBranch, which is the merge ref (44/merge), and checking out a local main changes
-      # nothing. Presenting the run as a push to main is what gets past that. The checkout
-      # is still pointed at main so git agrees, and because a pull request checkout is the
-      # merge commit, the notes describe the merge result rather than the branch tip.
-      # --no-ci is needed as well: on a pull request semantic-release otherwise stops
-      # before generateNotes (semantic-release/index.js:59).
+      # that name from env-ci rather than from git: on a pull_request event env-ci returns
+      # the merge ref, so checking out a local main changes nothing on its own. Presenting
+      # the run as a push to main is what gets past that, and it has to be done with env(1)
+      # rather than a step-level env: block — the runner re-injects its own GITHUB_* values
+      # over anything declared there, which is why the previous attempt still saw
+      # refs/pull/<n>/merge. The checkout is pointed at main as well so git agrees, and
+      # because a pull request checkout is the merge commit, the notes describe the merge
+      # result rather than the branch tip. --no-ci is needed too: on a pull request
+      # semantic-release otherwise stops before generateNotes (semantic-release/index.js:59).
       - name: Generate the notes a release would produce
         shell: bash
         run: |
           git checkout -B main
-          npx semantic-release --dry-run --no-ci --branches main 2>&1 | tee /tmp/dry-run.log
+          env GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+            npx semantic-release --dry-run --no-ci --branches main 2>&1 | tee /tmp/dry-run.log
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EVENT_NAME: push
-          GITHUB_REF: refs/heads/main
 
       # An empty changelog is the failure to catch, and it exits 0, so the notes have to
       # be inspected rather than the status code. Every generated entry links to its

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,10 @@
-module.exports = {
-  plugins: [
+// The release-notes check in CI runs semantic-release against a throwaway local clone so
+// it needs no credentials of any kind. Only the plugins that shape the notes are wanted
+// there: the publishing ones would be verifying an access it deliberately does not have,
+// and none of them contribute a line to the changelog.
+const notesOnly = process.env.RELEASE_NOTES_CHECK === '1';
+
+const plugins = [
     '@semantic-release/commit-analyzer',
     [
       '@semantic-release/release-notes-generator',
@@ -50,7 +55,16 @@ module.exports = {
         failComment: false,
       },
     ],
-  ],
+];
+
+module.exports = {
+  plugins: notesOnly
+    ? plugins.filter((plugin) =>
+        ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/exec'].includes(
+          Array.isArray(plugin) ? plugin[0] : plugin,
+        ),
+      )
+    : plugins,
   preset: 'conventionalcommits',
   branches: [{ name: 'main' }, { name: 'dev', channel: 'beta', prerelease: true }],
 };

--- a/release.config.js
+++ b/release.config.js
@@ -5,64 +5,66 @@
 const notesOnly = process.env.RELEASE_NOTES_CHECK === '1';
 
 const plugins = [
-    '@semantic-release/commit-analyzer',
-    [
-      '@semantic-release/release-notes-generator',
-      {
-        preset: 'conventionalcommits',
-        presetConfig: {
-          types: [
-            { type: 'feat', section: 'Features' },
-            { type: 'fix', section: 'Bug Fixes' },
-            { type: 'doc', hidden: false, section: 'Documentation' },
-            { type: 'docs', hidden: false, section: 'Documentation' },
-            { type: 'chore', hidden: true, section: 'Chores' },
-          ],
-        },
+  '@semantic-release/commit-analyzer',
+  [
+    '@semantic-release/release-notes-generator',
+    {
+      preset: 'conventionalcommits',
+      presetConfig: {
+        types: [
+          { type: 'feat', section: 'Features' },
+          { type: 'fix', section: 'Bug Fixes' },
+          { type: 'doc', hidden: false, section: 'Documentation' },
+          { type: 'docs', hidden: false, section: 'Documentation' },
+          { type: 'chore', hidden: true, section: 'Chores' },
+        ],
       },
-    ],
-    '@semantic-release/changelog',
-    [
-      '@semantic-release/npm',
-      {
-        npmPublish: false,
-      },
-    ],
-    [
-      // Rebuild once the new version is in package.json, so the bundle that is committed
-      // and attached to the release carries it too.
-      '@semantic-release/exec',
-      {
-        // Appended to the generated notes. See scripts/release-notes.js.
-        generateNotesCmd: 'node scripts/release-notes.js ${nextRelease.version}',
-        // Rebuild once the new version is in package.json.
-        prepareCmd: 'npm run build',
-      },
-    ],
-    [
-      '@semantic-release/git',
-      {
-        assets: ['CHANGELOG.md', 'README.md', 'package.json', 'package-lock.json', 'dist/decluttering-card-plus.js'],
-      },
-    ],
-    [
-      '@semantic-release/github',
-      {
-        assets: 'dist/*.js',
-        // Commit messages cite issue numbers from the upstream repository, which do not
-        // exist here; the comment step fails the whole run trying to resolve them.
-        successComment: false,
-        failComment: false,
-      },
-    ],
+    },
+  ],
+  '@semantic-release/changelog',
+  [
+    '@semantic-release/npm',
+    {
+      npmPublish: false,
+    },
+  ],
+  [
+    // Rebuild once the new version is in package.json, so the bundle that is committed
+    // and attached to the release carries it too.
+    '@semantic-release/exec',
+    {
+      // Appended to the generated notes. See scripts/release-notes.js.
+      generateNotesCmd: 'node scripts/release-notes.js ${nextRelease.version}',
+      // Rebuild once the new version is in package.json.
+      prepareCmd: 'npm run build',
+    },
+  ],
+  [
+    '@semantic-release/git',
+    {
+      assets: ['CHANGELOG.md', 'README.md', 'package.json', 'package-lock.json', 'dist/decluttering-card-plus.js'],
+    },
+  ],
+  [
+    '@semantic-release/github',
+    {
+      assets: 'dist/*.js',
+      // Commit messages cite issue numbers from the upstream repository, which do not
+      // exist here; the comment step fails the whole run trying to resolve them.
+      successComment: false,
+      failComment: false,
+    },
+  ],
 ];
 
 module.exports = {
   plugins: notesOnly
     ? plugins.filter((plugin) =>
-        ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release/exec'].includes(
-          Array.isArray(plugin) ? plugin[0] : plugin,
-        ),
+        [
+          '@semantic-release/commit-analyzer',
+          '@semantic-release/release-notes-generator',
+          '@semantic-release/exec',
+        ].includes(Array.isArray(plugin) ? plugin[0] : plugin),
       )
     : plugins,
   preset: 'conventionalcommits',


### PR DESCRIPTION
Follows #43. Closes the gap that let #42 through green.

CI ran `eslint`, `rollup` and the unit tests — nothing touching `semantic-release`. The release pipeline was only ever exercised by an actual release, so a dependency that broke note generation would surface as a shipped release with an empty changelog.

Adds a `release-notes` job that runs `semantic-release --dry-run` and inspects what comes back.

### Why it inspects the output, not the exit code

The failure mode exits 0. On `conventional-changelog-conventionalcommits@10` the notes collapse to a bare version heading, no error, no warning. Every generated entry links to its commit, so the job counts those links — zero means the changelog would ship empty.

### Getting a pull request as far as generated notes

Three obstacles, each confirmed in the source rather than assumed:

| obstacle | resolution |
|---|---|
| the branch name comes from `env-ci`, not git — on a `pull_request` event it is the merge ref | present the run as a push to `main`. A step-level `env:` block does **not** work: the runner re-injects its own `GITHUB_*` values over it, so the override goes through `env(1)` |
| in CI on a PR it stops before `generateNotes` (`semantic-release/index.js:59`) | `--no-ci` |
| it refuses to run unless it can push — `verifyAuth` failing is fatal either way, since an up-to-date branch rethrows as `EGITNOPERMISSION` (`index.js:97`) | point git at a throwaway bare clone whose `main` is the base commit |

That last one is the important one. The alternative was granting `contents: write` to a job that checks out pull request code and then executes `scripts/release-notes.js` from it. The stand-in remote needs **no token and no added permissions**.

semantic-release still receives the real GitHub URL, because the notes embed it in every commit link and a `file://` URL leaves the entries unlinked; `insteadOf` redirects git underneath it. No fidelity is lost — which commits the notes cover is decided by the release tags, not by where the remote branch sits.

`RELEASE_NOTES_CHECK` trims the plugin list to the three that shape the notes. The publishing plugins would be verifying access this run deliberately does not have, and none contribute a line to the changelog. The preset config object is **shared with the real list rather than copied**, so the section mapping cannot drift.

### Verification

One harness, only the dependency changed:

| | result |
|---|---|
| `ccc@8.0.0` | Features + Bug Fixes + Documentation, 5 linked entries |
| `ccc@10.3.0` (the #42 bump) | **version heading alone** |
| no releasable commits | passes, nothing to check |
| release reported, no notes printed | **fails** |

And live on this PR: found `v1.0.0`, computed `1.1.0`, generated 3 sections and **6 commit entries**, guard passed. This job would have caught #42.