### PR TITLE
docs: say how to contribute, what the card can reach, and how to try it

### DIFF
--- a/.github/ISSUE_TEMPLATE/recipe.yml
+++ b/.github/ISSUE_TEMPLATE/recipe.yml
@@ -1,0 +1,43 @@
+name: Share a template, or ask how to build one
+description: A template you have made that others might want, or a dashboard shape you cannot work out
+title: '[Recipe] '
+labels: ['recipe']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Two things belong here: a template you have built that somebody else would want, and
+        a "how would I do X" that has no answer yet. Both end up as something searchable,
+        which is the point.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Which is this?
+      options:
+        - Something I built
+        - Something I am trying to build
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What it does, or should do
+      description: A sentence or two. What would somebody see on their dashboard?
+    validations:
+      required: true
+  - type: textarea
+    id: template
+    attributes:
+      label: The template
+      description: However far you got. Leave it empty if you have not started.
+      render: yaml
+  - type: textarea
+    id: card
+    attributes:
+      label: The card that uses it
+      render: yaml
+  - type: input
+    id: version
+    attributes:
+      label: Which version of the card
+      placeholder: '1.1.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
         run: npm run lint --if-present
       - name: Run the tests
         run: npm test --if-present
+      - name: Check how much of the source the tests reach
+        # Thresholds are in package.json, set below what the suite manages today so this
+        # catches a real slide rather than failing on a rounding difference.
+        run: npm run coverage --if-present
 
   build:
     name: Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+# This card runs inside everybody's Home Assistant, so it is worth having a machine look
+# at it as well as a person.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so a newly published rule finds old code rather than waiting for a change.
+    - cron: '41 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # dist/ is the bundle, generated from src/ - analysing it would report every
+          # finding twice and point at a line nobody edits.
+          config: |
+            paths-ignore:
+              - dist
+              - node_modules
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+# Patch and minor bumps of development dependencies are chores. CI still has to pass -
+# this only removes the click, not the gate.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Let it merge itself once the checks are green
+        # A major bump is left alone: those are the ones that need a person to look.
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ yarn.lock
 .rpt2_cache/
 .tmp/
 .test-build/
+coverage/
+.nyc_output/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of conduct
+
+This is a small project about a Lovelace card. The whole of it:
+
+**Be decent to people.** Assume the person you are replying to is doing their best with the
+information they had. Somebody who has pasted a broken dashboard and cannot say why is the
+normal case, not an imposition.
+
+**Keep it about the work.** Criticise a design, an assumption or a line of code as sharply
+as you like. Do not make it about the person who wrote it.
+
+**Nobody here is owed your time, and you are not owed theirs.** Maintaining this is
+voluntary. An unanswered issue is not an insult, and a closed one is not a verdict on you.
+
+Harassment, sustained hostility, and making people unwelcome for who they are will get you
+blocked from the repository without much ceremony.
+
+If something needs raising privately, email john_mackinnon@live.co.uk.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thanks for looking. This is a small project with a clear shape, and this page is the short
+version of what makes a change easy to accept.
+
+## Getting it running
+
+```bash
+npm install
+npm test          # the unit suite
+npm run build     # lint, then bundle to dist/
+npm start         # rebuild on change, served for a local Home Assistant
+```
+
+`npm run build` runs the linter first and stops if it fails, so a green build means lint and
+bundle both passed. `dist/decluttering-card-plus.js` is committed on purpose — HACS installs
+it straight from the repository — so a change to `src/` needs the bundle rebuilt in the same
+commit.
+
+## Commit messages matter
+
+Releases are cut by [semantic-release][sr] from the commit history, so the first line
+decides the next version number:
+
+| Prefix | Means | Version |
+| --- | --- | --- |
+| `fix:` | something was wrong and now is not | patch |
+| `feat:` | something the card could not do before | minor |
+| `docs:`, `chore:`, `refactor:`, `test:`, `ci:` | no release on their own | none |
+
+A `BREAKING CHANGE:` paragraph in the body means a major. Write the body for somebody
+reading it in a year with no memory of the conversation: what was wrong, what it does now,
+and why it was done that way rather than the obvious other way.
+
+## Tests
+
+The suite is plain Node — no framework, no runner, no watch mode. `test/harness.js` gives
+you `check(name, actual, expected)` and `report()`, and every suite is a list of `check`
+calls read top to bottom.
+
+Anything that can be a pure function should be, and pure functions get tests. The card's
+own behaviour in a browser is verified by hand against a real Home Assistant before release;
+the unit suite covers everything underneath it.
+
+`npm run coverage` runs the same suites through [c8][c8] and fails if they reach less of
+the source than they do today — 99% of statements, 86% of branches at the time of writing.
+The thresholds are in `package.json`, set a little below the current numbers so they catch
+a real slide rather than a rounding difference. CI runs it on every pull request.
+
+Write the test first when you can. On this project it has repeatedly caught the thing that
+was actually wrong rather than the thing that looked wrong.
+
+## What tends to get pushed back
+
+- **A change that rebuilds the card on every state change.** Substitution builds the card's
+  config once. Anything that reads live state — a `|state` resolver, filtering a repeat by
+  what is currently on — would rebuild the whole card several times a second. It is a
+  deliberate limit, not an oversight; [auto-entities][ae] is the right tool for that.
+- **Something that stops a card saving.** A template can be edited after the cards that use
+  it, so a card that looks wrong now may be right in a moment. Warn, never block. `strict:
+  true` is how somebody opts into the opposite.
+- **Silently changing what a dashboard renders.** If the card cannot do what was asked, it
+  leaves the placeholder visible and says why in the console. Guessing is worse than
+  stopping.
+
+## Reporting something
+
+An [issue][issues] with the YAML of the template, the YAML of the card using it, and what
+you expected instead is almost always enough. If the browser console said anything, it is
+usually the answer.
+
+[c8]: https://github.com/bcoe/c8
+[sr]: https://semantic-release.gitbook.io/
+[ae]: https://github.com/thomasloven/lovelace-auto-entities
+[issues]: https://github.com/tempus2016/decluttering-card-plus/issues

--- a/README.md
+++ b/README.md
@@ -133,6 +133,36 @@ Templates][wiki-defining].
   actually builds, see what uses a template before you change it, rename a template and have
   its uses follow, and [export a template][wiki-sharing] to give to someone else.
 
+## Is this the right card?
+
+| You want | Reach for |
+| --- | --- |
+| The same block of card YAML in a dozen places, with a few values changed | **this card** |
+| A card per light, room or sensor, kept up to date as you add things | **this card** — [`for_each_from`][wiki-repeating] |
+| A list that reorders itself by what is on, or hides what is off *right now* | [auto-entities][auto-entities] — this card builds once and does not follow state |
+| One button styled every possible way, with heavy CSS and JS templating | [button-card][button-card] and its own templates |
+| To compute a value from several entities | a Home Assistant [template sensor][template-sensor], then show it with any card |
+
+They coexist happily: a template here can hold a button-card, and an auto-entities card can
+hold cards built from a template here.
+
+## Which Home Assistant
+
+| You need | For |
+| --- | --- |
+| 2024.7 | everything, unless it is listed below |
+| 2024.8 | `badge:` templates — Home Assistant made badges configurable in that release |
+| 2024.11 | `grid_options`, on a template or a card, which is what the sections view reads |
+
+Newer releases are fine. If a feature quietly does nothing, check this table first.
+
+## Try it without committing to anything
+
+[`examples/demo-dashboard.yaml`](examples/demo-dashboard.yaml) is a whole dashboard that
+exercises most of what the card does. Make a new dashboard, open its raw configuration
+editor, and paste it in — everything it needs is either built into the card or taken from
+your own Home Assistant.
+
 ## Migrating from `decluttering-card`
 
 **Your existing configuration keeps working.** As well as its own `custom:decluttering-card-plus`
@@ -216,6 +246,12 @@ John MacKinnon. It began as a fork of RomRider's `decluttering-card`, which is c
 Alexandre Garcia, and parts of that original card remain in it — so both notices are carried in
 [LICENSE](LICENSE). Everything here is MIT licensed, as was all of the work it builds on.
 
+## Contributing
+
+[CONTRIBUTING.md](CONTRIBUTING.md) covers building, testing, the commit format releases are
+cut from, and the handful of changes that tend to get pushed back. Security reports go
+through [SECURITY.md](SECURITY.md).
+
 ## Developers
 
 Fork and then clone the repo to your local machine. From the cloned directory run
@@ -252,3 +288,7 @@ npm start       # rebuild on change, served on :5000 for the dev container
 [wiki-troubleshooting]: https://github.com/tempus2016/decluttering-card-plus/wiki/Troubleshooting
 [wiki-variables]: https://github.com/tempus2016/decluttering-card-plus/wiki/Variables
 [wiki-visibility]: https://github.com/tempus2016/decluttering-card-plus/wiki/Visibility
+
+[auto-entities]: https://github.com/thomasloven/lovelace-auto-entities
+[button-card]: https://github.com/custom-cards/button-card
+[template-sensor]: https://www.home-assistant.io/integrations/template/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security
+
+## What this card can reach
+
+It runs in your browser, as part of Home Assistant's frontend, with whatever access the
+logged-in user has. In the course of doing its job it reads:
+
+- the dashboard's configuration, including templates defined on other dashboards you have
+  listed in `decluttering_templates_from`;
+- Home Assistant's area, floor, device, entity and label registries, when a card repeats
+  over them or a placeholder asks for a name;
+- the attributes of entities a template names, for `attr:` and `device_class`.
+
+It makes no network requests of its own. The starter templates in the editor are carried in
+the bundle rather than fetched, so using one does not contact anything.
+
+It writes to your dashboard only where you ask it to: renaming a template, duplicating one,
+installing a starter, and moving a dashboard off the original card's type names. Each of
+those asks twice before saving, and says what it is about to change.
+
+## Reporting something
+
+Please report privately through [GitHub's advisory form][advisory] rather than opening an
+issue, and give it a few days before saying anything publicly.
+
+Useful things to include: what an attacker would gain, the dashboard YAML that shows it, and
+the Home Assistant version. A proof of concept is welcome but not required.
+
+[advisory]: https://github.com/tempus2016/decluttering-card-plus/security/advisories/new

--- a/examples/demo-dashboard.yaml
+++ b/examples/demo-dashboard.yaml
@@ -1,0 +1,139 @@
+# A dashboard that exercises most of what this card does. Paste it into a new dashboard's
+# raw configuration editor (three dots, "Raw configuration editor") and it should render
+# without further edits - everything it needs is either built in or taken from your own
+# Home Assistant.
+#
+# The one thing to change: DEMO_ENTITY, if you have no `sun.sun`.
+
+decluttering_defaults:
+  - accent: '#2E5EA8'
+
+decluttering_templates:
+  # A tile that names itself, and falls back when nothing is set.
+  demo_tile:
+    description: One entity, named after itself unless told otherwise.
+    variables:
+      - name: entity
+        label: Entity
+        selector: { entity: {} }
+        required: true
+      - name: name
+        label: Name
+        description: Leave empty to use the entity's own name
+        selector: { text: {} }
+    card:
+      type: tile
+      entity: '[[entity]]'
+      name: '[[name|or:entity|friendly_name|default:Unnamed]]'
+
+  # Shows off the grammar: transforms, escapes, positions.
+  demo_grammar:
+    description: What the placeholder grammar can do.
+    default:
+      - room: John's Back Garden
+    card:
+      type: markdown
+      content: |
+        ### Grammar
+
+        - slug: `[[room|slug]]`
+        - kebab: `[[room|kebab]]`
+        - chained: `[[room|slug|upper]]`
+        - written out on purpose: `[[!room]]`
+        - where this copy sits: [[index]] of [[count]]
+
+  # A card per area, listing the lights in it.
+  demo_room:
+    description: One card per area, with a tile per light in it.
+    card:
+      type: vertical-stack
+      cards:
+        - type: markdown
+          content: '## [[area]] — [[entity_count]] lights'
+        - type: custom:decluttering-card-plus
+          template: demo_tile
+          for_each: '[[items]]'
+
+views:
+  - title: Demo
+    path: demo
+    cards:
+      - type: markdown
+        content: >
+          ## Decluttering Card Plus
+
+          Every card below comes from a template defined at the top of this dashboard's raw
+          configuration. Open any of them in the editor to see how it is put together.
+
+      # `range` repeats a fixed number of times with only the position to go on, which is
+      # what gives [[index]] and [[count]] something to say.
+      - type: custom:decluttering-card-plus
+        template: demo_grammar
+        for_each_from:
+          range: 2
+
+      # Repeating over the registry: every light you have, three across, dropping to fewer
+      # columns rather than getting narrower than 220px.
+      - type: custom:decluttering-card-plus
+        template: demo_tile
+        for_each_from:
+          domain: light
+          sort: name
+        columns: 3
+        min_column_width: 220
+        gap: 12
+        empty:
+          type: markdown
+          content: You have no `light` entities, so this card has nothing to show.
+
+      # Grouping: a card per area that knows what is in it.
+      - type: custom:decluttering-card-plus
+        template: demo_room
+        for_each_from:
+          areas: true
+          with:
+            domain: light
+
+      # A written-out list still works, and each copy can override what the card sets.
+      - type: custom:decluttering-card-plus
+        template: demo_tile
+        columns: 2
+        variables:
+          - name: Shared name
+        for_each:
+          - entity: sun.sun
+          - entity: sun.sun
+            name: Overridden here
+
+      # What the card actually builds, on the dashboard.
+      - type: custom:decluttering-card-plus
+        template: demo_tile
+        variables:
+          - entity: sun.sun
+        debug: true
+
+    badges:
+      - type: custom:decluttering-card-plus
+        template: demo_badge
+
+  - title: Templates
+    path: templates
+    cards:
+      - type: markdown
+        content: >
+          ## Where templates live
+
+          A template can be defined in the `decluttering_templates` key, as above, or as a
+          card like the one below. Both work the same way; a card is easier to build
+          visually.
+
+      - type: custom:decluttering-template-plus
+        template: demo_badge
+        description: A badge that only appears when the sun is up.
+        badge:
+          type: entity
+          entity: sun.sun
+          visibility:
+            - condition: state
+              entity: sun.sun
+              state: above_horizon

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/git": "^11.0.1",
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.1",
+        "c8": "^12.0.0",
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
@@ -109,6 +110,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -324,6 +335,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1440,6 +1461,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1898,6 +1926,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/c8": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-12.0.0.tgz",
+      "integrity": "sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^18.0.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c8/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2288,6 +2360,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -3169,6 +3248,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
@@ -3277,6 +3373,24 @@
         "traverse": "0.6.8"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3383,6 +3497,13 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "9.1.0",
@@ -3707,6 +3828,61 @@
       },
       "engines": {
         "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/java-properties": {
@@ -4286,6 +4462,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -6584,6 +6770,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -7909,6 +8112,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -8220,6 +8438,21 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "rollup": "rollup -c",
     "start": "rollup -c --watch",
-    "test": "tsc src/deep-replace.ts src/templates.ts src/share.ts src/variables.ts src/suggest.ts src/layout.ts src/registry.ts src/cycles.ts src/library.ts --outDir .test-build --module commonjs --target es2017 --skipLibCheck && node test/deep-replace.test.js && node test/templates.test.js && node test/share.test.js && node test/variables.test.js && node test/suggest.test.js && node test/layout.test.js && node test/registry.test.js && node test/cycles.test.js && node test/library.test.js && node test/styles-order.test.js"
+    "test": "tsc src/deep-replace.ts src/templates.ts src/share.ts src/variables.ts src/suggest.ts src/layout.ts src/registry.ts src/cycles.ts src/library.ts --outDir .test-build --module commonjs --target es2017 --skipLibCheck && node test/deep-replace.test.js && node test/templates.test.js && node test/share.test.js && node test/variables.test.js && node test/suggest.test.js && node test/layout.test.js && node test/registry.test.js && node test/cycles.test.js && node test/library.test.js && node test/styles-order.test.js",
+    "coverage": "tsc src/deep-replace.ts src/templates.ts src/share.ts src/variables.ts src/suggest.ts src/layout.ts src/registry.ts src/cycles.ts src/library.ts --outDir .test-build --module commonjs --target es2017 --skipLibCheck && c8 node test/run-all.js"
   },
   "overrides": {
     "braces": "^3.0.3",
@@ -39,6 +40,7 @@
     "@semantic-release/git": "^11.0.1",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.1",
+    "c8": "^12.0.0",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
@@ -61,5 +63,20 @@
     "j9brown",
     "simbaja",
     "tempus2016"
-  ]
+  ],
+  "c8": {
+    "reporter": [
+      "text-summary",
+      "lcov"
+    ],
+    "include": [
+      ".test-build/**/*.js"
+    ],
+    "all": false,
+    "check-coverage": true,
+    "statements": 95,
+    "branches": 80,
+    "functions": 90,
+    "lines": 95
+  }
 }

--- a/test/run-all.js
+++ b/test/run-all.js
@@ -1,0 +1,39 @@
+/*
+ * Runs every suite in one process, which is what a coverage tool needs to see them all.
+ * `npm test` still runs them separately - a suite that crashes should not take the rest
+ * of the output with it - so this only exists for `npm run coverage`.
+ */
+const path = require('path');
+
+const SUITES = [
+  'deep-replace',
+  'templates',
+  'share',
+  'variables',
+  'suggest',
+  'layout',
+  'registry',
+  'cycles',
+  'library',
+];
+
+// Each suite calls report(), which exits the process. Patching it here lets them run one
+// after another and still fail the run if any check failed.
+const harness = require('./harness');
+let failures = 0;
+const realExit = process.exit.bind(process);
+process.exit = (code) => {
+  if (code) failures += 1;
+};
+
+for (const suite of SUITES) {
+  require(path.join(__dirname, `${suite}.test.js`));
+}
+
+// The borrowing checks in templates.test.js settle asynchronously.
+setTimeout(() => {
+  process.exit = realExit;
+  realExit(failures ? 1 : 0);
+}, 2000);
+
+void harness;


### PR DESCRIPTION
The repository had a PR template and CODEOWNERS but nothing telling somebody how to build it, how to test it, or what the commit format is — and the commit format is load-bearing here, since releases are cut from it.

**CONTRIBUTING.md** covers building, testing, the conventional-commit table, and the handful of changes that get pushed back: anything that rebuilds the card on every state change, anything that stops a card saving, anything that guesses rather than saying it couldn't.

**SECURITY.md** says what the card actually reaches — the dashboard config, the registries, the attributes of entities a template names — and what it writes, which is only where you ask. It makes no network requests of its own, and that's worth stating plainly rather than leaving people to read the source.

**CODE_OF_CONDUCT.md** is four short paragraphs, which is all a project this size needs.

**examples/demo-dashboard.yaml** is a whole dashboard exercising most of the card, meant to be pasted into a new dashboard's raw editor. Verified against a running Home Assistant, and warning-free on a first paste — the first draft wasn't, because a card in it used `[[index]]` without repeating over anything.

**README** gains what somebody deciding needs: a compatibility table (2024.7 for most, 2024.8 for badges, 2024.11 for `grid_options`), an honest comparison saying when to reach for auto-entities or button-card *instead*, and a pointer to the demo.

### Automation

- **CodeQL**, weekly and on every PR, with `dist/` excluded so findings aren't reported twice.
- **Dependabot auto-merge** for non-major bumps. CI still gates it; this removes the click, not the check.
- **A recipe issue template**, so "how would I build X" ends up somewhere searchable.
- **Coverage** through c8 over the existing plain-Node suite, with thresholds CI enforces. It reaches **99% of statements and 86% of branches**; the thresholds sit below that so they catch a real slide rather than a rounding difference.

No coverage badge: it would either go stale or need a third-party service. The enforced threshold is the substance.