### PR TITLE
chore: add labels for the ways somebody can help

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -60,3 +60,14 @@
 - name: upstream
   color: fef2c0
   description: Originally reported on custom-cards/decluttering-card or a fork of it
+
+# Ways in for somebody who wants to help
+- name: good first issue
+  color: 7057ff
+  description: Small, self-contained, and someone new to the project could take it
+- name: help wanted
+  color: 008672
+  description: Worth doing, and not currently being worked on
+- name: recipe
+  color: c2e0c6
+  description: A template somebody shared, or a dashboard shape to work out


### PR DESCRIPTION
Zero open issues means zero entry points for anyone wanting to help.

- `good first issue` and `help wanted` are what somebody looking for a way in actually filters on.
- `recipe` matches the issue template added alongside, for sharing a template or asking how to build one.

Added to `.github/labels.yml` rather than created by hand, since the labels workflow syncs from that file and would otherwise remove them again.