### PR TITLE
chore(deps): bump github/codeql-action from 3.37.8 to 4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
-      - uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           # dist/ is the bundle, generated from src/ - analysing it would report every
@@ -35,6 +35,6 @@ jobs:
               - dist
               - node_modules
 
-      - uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
Dependabot split this into #91 (init) and #95 (analyze). Each one fails on its own, because the workflow then runs a v4 config against a v3 runner:

```
Loaded a configuration file for version '4.37.7', but running version '3.37.8'
```

Both pins move together here, so closing #91 and #95 in favour of this.